### PR TITLE
feat(qa): test strategy + unit tests + local dev runbook

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "war-dashboard-backend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "wrangler dev",
+    "build": "wrangler deploy --dry-run",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "type-check": "tsc --noEmit",
+    "db:migrate": "drizzle-kit migrate",
+    "db:seed": "tsx src/db/seed.ts",
+    "db:reset": "drizzle-kit drop && drizzle-kit migrate && tsx src/db/seed.ts"
+  },
+  "dependencies": {
+    "hono": "^4.0.0",
+    "drizzle-orm": "^0.30.0",
+    "@hono/zod-validator": "^0.2.0"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "drizzle-kit": "^0.20.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^1.0.0",
+    "wrangler": "^3.0.0"
+  }
+}

--- a/backend/src/agents/__tests__/alertMatcher.test.ts
+++ b/backend/src/agents/__tests__/alertMatcher.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { haversineKm } from '../alertMatcher'
+
+describe('haversineKm', () => {
+  it('London to Paris is ~340km', () => {
+    expect(haversineKm(51.5, -0.12, 48.85, 2.35)).toBeCloseTo(340, -1)
+  })
+
+  it('same point is 0km', () => {
+    expect(haversineKm(32.08, 34.78, 32.08, 34.78)).toBe(0)
+  })
+
+  it('Tel Aviv to Beirut is ~230km', () => {
+    expect(haversineKm(32.08, 34.78, 33.89, 35.5)).toBeCloseTo(230, -1)
+  })
+
+  it('alert within radius is matched', () => {
+    // Pin at Tel Aviv (32.08, 34.78), radius 100km
+    // Alert at Jerusalem (31.77, 35.21) — ~62km away
+    const dist = haversineKm(32.08, 34.78, 31.77, 35.21)
+    expect(dist).toBeLessThan(100)
+  })
+
+  it('alert outside radius is not matched', () => {
+    // Pin at Tel Aviv (32.08, 34.78), radius 100km
+    // Alert at Beirut (33.89, 35.50) — ~230km away
+    const dist = haversineKm(32.08, 34.78, 33.89, 35.5)
+    expect(dist).toBeGreaterThan(100)
+  })
+
+  it('New York to Los Angeles is ~3940km', () => {
+    expect(haversineKm(40.71, -74.01, 34.05, -118.24)).toBeCloseTo(3940, -2)
+  })
+})

--- a/backend/src/agents/__tests__/confidenceScorer.test.ts
+++ b/backend/src/agents/__tests__/confidenceScorer.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest'
+import { scoreConfidence } from '../confidenceScorer'
+
+describe('scoreConfidence', () => {
+  it('returns RUMOR with no sources', () => {
+    const result = scoreConfidence({ sources: [], ageMinutes: 60 })
+    expect(result.label).toBe('RUMOR')
+    expect(result.score).toBeLessThan(0.5)
+  })
+
+  it('returns VERIFIED for Reuters + AP + BBC corroboration', () => {
+    const result = scoreConfidence({
+      sources: ['Reuters', 'AP', 'BBC'],
+      ageMinutes: 120,
+    })
+    expect(result.label).toBe('VERIFIED')
+    expect(result.score).toBeGreaterThanOrEqual(0.9)
+  })
+
+  it('applies freshness penalty for breaking news < 15min old', () => {
+    const fresh = scoreConfidence({
+      sources: ['Reuters', 'AP'],
+      ageMinutes: 5,
+    })
+    const aged = scoreConfidence({
+      sources: ['Reuters', 'AP'],
+      ageMinutes: 60,
+    })
+    // Fresh breaking news should score lower due to freshness penalty
+    expect(fresh.score).toBeLessThan(aged.score)
+  })
+
+  it('caps score at 0.98', () => {
+    const result = scoreConfidence({
+      sources: ['Reuters', 'AP', 'BBC', 'NYT', 'Guardian', 'Al Jazeera'],
+      ageMinutes: 240,
+    })
+    expect(result.score).toBeLessThanOrEqual(0.98)
+  })
+
+  it('returns LIKELY for single BBC source', () => {
+    const result = scoreConfidence({
+      sources: ['BBC'],
+      ageMinutes: 60,
+    })
+    expect(result.label).toBe('LIKELY')
+    expect(result.score).toBeGreaterThanOrEqual(0.7)
+    expect(result.score).toBeLessThan(0.9)
+  })
+})

--- a/docs/projects/war-dashboard/runbooks/local-setup.md
+++ b/docs/projects/war-dashboard/runbooks/local-setup.md
@@ -1,0 +1,163 @@
+# Local Dev Setup Runbook — War News Intelligence Dashboard
+
+**Closes #22**
+
+---
+
+## Prerequisites
+
+- **Node.js 20+** — check: `node --version`
+- **npm 10+** — check: `npm --version`
+- **Git** — check: `git --version`
+- **Wrangler CLI** (for Cloudflare Workers backend) — `npm install -g wrangler`
+
+---
+
+## 1. Clone & Install
+
+```bash
+git clone https://github.com/TMA-OC/war-dashboard.git
+cd war-dashboard
+
+# Install frontend deps
+cd frontend && npm install && cd ..
+
+# Install backend deps
+cd backend && npm install && cd ..
+```
+
+---
+
+## 2. Environment Setup
+
+### Frontend — `frontend/.env.local`
+
+```env
+VITE_API_URL=http://localhost:8787
+VITE_MAPBOX_TOKEN=your_mapbox_token
+VITE_GOOGLE_MAPS_KEY=your_google_maps_key
+```
+
+- Get a free Mapbox token at https://mapbox.com (required for map view)
+- Google Maps key optional (used for geocoding only)
+
+### Backend — `backend/.env`
+
+```env
+DATABASE_URL=postgresql://postgres:<password>@db.<project-ref>.supabase.co:5432/postgres
+JWT_SECRET=any-random-32-char-string-here
+FRONTEND_URL=http://localhost:5173
+```
+
+Generate a JWT secret: `openssl rand -hex 16`
+
+---
+
+## 3. Database Setup (Supabase — Free Tier)
+
+1. Create account at https://supabase.com
+2. New project → choose region closest to you → set password
+3. Go to **Settings → Database → Connection String** → copy the URI
+4. Paste into `backend/.env` as `DATABASE_URL`
+5. Run migrations and seed:
+
+```bash
+cd backend
+npm run db:migrate
+npm run db:seed
+```
+
+---
+
+## 4. Start Dev Servers
+
+Open two terminals:
+
+```bash
+# Terminal 1 — Backend (Cloudflare Workers dev)
+cd backend && npx wrangler dev
+# Runs on http://localhost:8787
+```
+
+```bash
+# Terminal 2 — Frontend (Vite dev server)
+cd frontend && npm run dev
+# Runs on http://localhost:5173
+```
+
+---
+
+## 5. First Run
+
+1. Open http://localhost:5173
+2. Click **Register**
+3. Enter any email + password (8+ characters)
+4. You'll land on your dashboard
+5. Add a pin (country/region) to start seeing alerts
+
+---
+
+## 6. Running Tests
+
+```bash
+# Backend unit tests
+cd backend && npm test
+
+# Backend watch mode
+cd backend && npm run test:watch
+
+# Frontend unit tests
+cd frontend && npm run test:unit
+
+# E2E (Playwright) — requires both servers running
+npx playwright test
+```
+
+---
+
+## 7. Common Issues
+
+### `wrangler dev` fails — "Not authenticated"
+```bash
+npx wrangler login
+# Follow browser OAuth flow
+```
+
+### Database connection refused
+- Check your `DATABASE_URL` is correct (copy fresh from Supabase)
+- Ensure your IP isn't blocked — Supabase → Settings → Database → Connection Pooling
+
+### `VITE_API_URL` requests failing (CORS)
+- Verify `FRONTEND_URL=http://localhost:5173` is set in `backend/.env`
+- Restart `wrangler dev` after `.env` changes
+
+### Port already in use
+```bash
+# Kill whatever is on 8787
+lsof -ti:8787 | xargs kill -9
+# Kill whatever is on 5173
+lsof -ti:5173 | xargs kill -9
+```
+
+### Google OAuth not working locally
+- Add `http://localhost:5173/auth/callback` to your Google OAuth app's redirect URIs
+- This requires a Google Cloud project — see backend README for setup
+
+---
+
+## 8. Useful Commands
+
+```bash
+# Reset database
+cd backend && npm run db:reset
+
+# Build frontend for production
+cd frontend && npm run build
+
+# Preview production build
+cd frontend && npm run preview
+
+# Type check
+cd frontend && npm run type-check
+cd backend && npm run type-check
+```

--- a/docs/projects/war-dashboard/testing/test-strategy.md
+++ b/docs/projects/war-dashboard/testing/test-strategy.md
@@ -1,0 +1,132 @@
+# Test Strategy — War News Intelligence Dashboard
+
+**Version:** 1.0  
+**Owner:** QA Engineering (Vibe Unit)  
+**Last Updated:** 2026-03-01  
+**Issues:** Closes #21
+
+---
+
+## 1. Overview
+
+This document defines the test strategy for the War News Intelligence Dashboard — a real-time conflict monitoring platform with AI-powered confidence scoring, pin-based alert matching, and pro broadcast capabilities.
+
+Our goal: ship with confidence. Every critical user path must be covered before merge.
+
+---
+
+## 2. Test Pyramid
+
+```
+         /\
+        /E2E\         10% — Playwright, critical user journeys
+       /------\
+      /  Integ  \     20% — API routes, DB queries, SSE streams
+     /------------\
+    /     Unit      \  70% — Vitest, pure functions, components
+   /------------------\
+```
+
+| Layer       | % of Tests | Framework         | Scope                                      |
+|-------------|-----------|-------------------|--------------------------------------------|
+| Unit        | 70%       | Vitest            | Pure functions, Vue components, agents     |
+| Integration | 20%       | Vitest + Supertest| API routes, DB layer, SSE, OAuth flows     |
+| E2E         | 10%       | Playwright        | Full user journeys in real browser         |
+
+---
+
+## 3. Frameworks & Tooling
+
+### 3.1 Unit Testing — Vitest
+- **Backend:** `backend/vitest.config.ts` — tests in `src/**/__tests__/*.test.ts`
+- **Frontend:** `frontend/vitest.config.ts` — tests in `src/**/__tests__/*.test.ts`
+- Fast, ESM-native, same config as Vite
+- Coverage via `@vitest/coverage-v8`
+
+### 3.2 Component Testing — Vue Test Utils
+- `@vue/test-utils` for mounting Vue components in isolation
+- Mock Pinia stores with `createTestingPinia()`
+- Stub router with `createRouter`/`createMemoryHistory`
+
+### 3.3 E2E Testing — Playwright
+- Tests in `e2e/` at repo root
+- Browsers: Chromium (primary), Firefox (secondary)
+- Base URL: `http://localhost:5173`
+- Auth state stored in `e2e/fixtures/auth.json` via `storageState`
+
+### 3.4 API Performance — k6
+- Load scripts in `perf/` at repo root
+- Run in CI on schedule (not every PR)
+
+---
+
+## 4. Critical Paths
+
+### 4.1 Authentication
+
+| Test | Type | Priority |
+|------|------|----------|
+| Register with email + password | E2E | P0 |
+| Login with valid credentials | E2E | P0 |
+| Login with invalid credentials shows error | Unit/Integration | P0 |
+| Google OAuth redirect flow completes | E2E | P0 |
+| Session persists on page refresh | E2E | P1 |
+| Logout clears session + redirects | E2E | P0 |
+| JWT expiry triggers re-auth | Integration | P1 |
+| Rate limiting on /auth/login | Integration | P1 |
+
+### 4.2 Alert Feed
+
+| Test | Type | Priority |
+|------|------|----------|
+| User sees alerts for pinned country | Integration | P0 |
+| User sees alerts matching pinned topic | Integration | P0 |
+| User does NOT see alerts outside pins | Integration | P0 |
+| Feed filters by confidence threshold | Unit | P1 |
+| Feed sorted by newest first | Unit | P1 |
+
+### 4.3 Confidence Scoring
+
+Thresholds:
+- >= 0.90 → VERIFIED (green)
+- >= 0.70 → LIKELY (yellow)
+- >= 0.50 → UNCONFIRMED (orange)
+- < 0.50  → RUMOR (red)
+
+### 4.4 Pin Proximity — Haversine distance against pin radius.
+
+### 4.5 RSS Deduplication — Same headline from 2 sources → 1 alert, 2 sources listed.
+
+### 4.6 SSE — New alert pushed to connected client within 5s of ingestion.
+
+### 4.7 Pro Broadcast View — Renders correctly at 1920x1080, branding applied.
+
+### 4.8 Map — Markers render at correct coordinates, clicking shows popup.
+
+---
+
+## 5. Performance Targets
+
+| Metric | Target |
+|--------|--------|
+| GET /alerts p95 latency | < 200ms |
+| Vite production build | < 30s |
+| Initial page load (individual dashboard) | < 3s on 4G |
+| Map renders 500 markers | No frame drop |
+
+---
+
+## 6. PR Regression Checklist
+
+- [ ] Unit tests added/updated for changed logic
+- [ ] Integration tests cover API contract changes
+- [ ] `vitest run` passes locally (backend + frontend)
+- [ ] Login / register flow still works
+- [ ] Confidence scoring thresholds unchanged or re-tested
+- [ ] Pin proximity logic unchanged or unit tested
+- [ ] RSS deduplication not regressed
+- [ ] SSE still pushes within 5s
+- [ ] ConfidenceBadge renders correct label + color
+- [ ] Broadcast view renders at 1920x1080
+- [ ] Map markers and popups work
+- [ ] Vite build still < 30s

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "war-dashboard-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vue-tsc && vite build",
+    "preview": "vite preview",
+    "test:unit": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "type-check": "vue-tsc --noEmit",
+    "lint": "eslint . --ext .vue,.ts,.tsx"
+  },
+  "dependencies": {
+    "vue": "^3.4.0",
+    "vue-router": "^4.3.0",
+    "pinia": "^2.1.0",
+    "@vueuse/core": "^10.0.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^5.0.0",
+    "@vitest/coverage-v8": "^1.0.0",
+    "@vue/test-utils": "^2.4.0",
+    "typescript": "^5.0.0",
+    "vite": "^5.0.0",
+    "vitest": "^1.0.0",
+    "vue-tsc": "^2.0.0"
+  }
+}

--- a/frontend/src/components/alerts/__tests__/ConfidenceBadge.test.ts
+++ b/frontend/src/components/alerts/__tests__/ConfidenceBadge.test.ts
@@ -1,0 +1,65 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import ConfidenceBadge from '../ConfidenceBadge.vue'
+
+describe('ConfidenceBadge', () => {
+  it('shows VERIFIED in green for score >= 0.9', () => {
+    const wrapper = mount(ConfidenceBadge, {
+      props: { score: 0.95 },
+    })
+    expect(wrapper.text()).toContain('VERIFIED')
+    expect(wrapper.classes()).toContain('badge--verified')
+    // Verify green color class or style
+    const badge = wrapper.find('[data-testid="confidence-badge"]')
+    expect(badge.classes().join(' ')).toMatch(/green|verified/)
+  })
+
+  it('shows LIKELY in yellow for score >= 0.7 and < 0.9', () => {
+    const wrapper = mount(ConfidenceBadge, {
+      props: { score: 0.75 },
+    })
+    expect(wrapper.text()).toContain('LIKELY')
+    expect(wrapper.classes()).toContain('badge--likely')
+  })
+
+  it('shows UNCONFIRMED in orange for score >= 0.5 and < 0.7', () => {
+    const wrapper = mount(ConfidenceBadge, {
+      props: { score: 0.55 },
+    })
+    expect(wrapper.text()).toContain('UNCONFIRMED')
+    expect(wrapper.classes()).toContain('badge--unconfirmed')
+  })
+
+  it('shows RUMOR in red for score < 0.5', () => {
+    const wrapper = mount(ConfidenceBadge, {
+      props: { score: 0.3 },
+    })
+    expect(wrapper.text()).toContain('RUMOR')
+    expect(wrapper.classes()).toContain('badge--rumor')
+    const badge = wrapper.find('[data-testid="confidence-badge"]')
+    expect(badge.classes().join(' ')).toMatch(/red|rumor/)
+  })
+
+  it('displays percentage rounded to nearest integer', () => {
+    const wrapper = mount(ConfidenceBadge, {
+      props: { score: 0.876 },
+    })
+    expect(wrapper.text()).toContain('88%')
+  })
+
+  it('displays 0% for score of 0', () => {
+    const wrapper = mount(ConfidenceBadge, {
+      props: { score: 0 },
+    })
+    expect(wrapper.text()).toContain('0%')
+    expect(wrapper.text()).toContain('RUMOR')
+  })
+
+  it('displays 98% for score of 0.98', () => {
+    const wrapper = mount(ConfidenceBadge, {
+      props: { score: 0.98 },
+    })
+    expect(wrapper.text()).toContain('98%')
+    expect(wrapper.text()).toContain('VERIFIED')
+  })
+})


### PR DESCRIPTION
## Summary

QA Engineering deliverables for Sprint 1:

### What's included

**Test Strategy** (`docs/projects/war-dashboard/testing/test-strategy.md`)
- Full test pyramid (unit 70% / integration 20% / E2E 10%)
- Vitest + Playwright framework setup
- Critical paths: auth, alert feed, confidence scoring, pin proximity, RSS dedup, SSE, broadcast view, map
- Performance targets: API p95 <200ms, build <30s, LCP <3s on 4G, 500 map markers
- PR regression checklist

**Unit Tests**
- `backend/src/agents/__tests__/confidenceScorer.test.ts` — RUMOR/LIKELY/VERIFIED thresholds, freshness penalty, score cap
- `backend/src/agents/__tests__/alertMatcher.test.ts` — haversineKm (London-Paris, Tel Aviv-Beirut, radius matching)
- `frontend/src/components/alerts/__tests__/ConfidenceBadge.test.ts` — all labels, colors, percentage display

**package.json scripts**
- Backend: `npm test`, `npm run test:watch`
- Frontend: `npm run test:unit`

**Local Dev Runbook** (`docs/projects/war-dashboard/runbooks/local-setup.md`)
- Prerequisites, clone, install, env setup, Supabase DB, dev servers, first run, common issues

Closes #21
Closes #22