### PR TITLE
[Backend] Geocoding pipeline

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "war-dashboard-backend",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.4.0",
+    "vitest": "^1.6.0"
+  },
+  "dependencies": {
+    "drizzle-orm": "^0.30.0",
+    "postgres": "^3.4.4"
+  }
+}

--- a/backend/src/agents/__tests__/geocoder.test.ts
+++ b/backend/src/agents/__tests__/geocoder.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Geocoding pipeline tests
+ */
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  extractLocations,
+  geocodeLocation,
+  geocodeTextAsync,
+  attachGeoToAlert,
+  getGeocodingStats,
+  resetGeocodingStats,
+  InMemoryKV,
+  ME_ENTITY_ALIASES,
+  EXTENDED_GEO_LOOKUP,
+} from "../geocoder";
+
+// ─── Location Extractor ───────────────────────────────────────────────────────
+
+describe("extractLocations", () => {
+  it("extracts Tel Aviv from article text", () => {
+    const text = "IDF forces in Tel Aviv are on high alert following missile strikes from Gaza.";
+    const locations = extractLocations(text);
+    expect(locations).toContain("tel aviv");
+  });
+
+  it("extracts Gaza from article text", () => {
+    const text = "Airstrikes pounded northern Gaza overnight, killing at least 20 civilians.";
+    const locations = extractLocations(text);
+    expect(locations).toContain("gaza");
+  });
+
+  it("resolves 'Gaza Strip' alias to 'gaza'", () => {
+    const text = "Humanitarian aid enters the Gaza Strip through the Rafah crossing.";
+    const locations = extractLocations(text);
+    expect(locations).toContain("gaza");
+  });
+
+  it("resolves 'Hezbollah' to 'beirut'", () => {
+    const text = "Hezbollah fired rockets at northern Israel on Sunday.";
+    const locations = extractLocations(text);
+    expect(locations).toContain("beirut");
+  });
+
+  it("resolves 'IRGC' to 'tehran'", () => {
+    const text = "IRGC commanders met in Tehran to discuss the operation.";
+    const locations = extractLocations(text);
+    expect(locations).toContain("tehran");
+  });
+
+  it("handles multiple locations", () => {
+    const text = "Missiles fired from Tehran targeted Tel Aviv and Haifa.";
+    const locations = extractLocations(text);
+    expect(locations).toContain("tehran");
+    expect(locations).toContain("tel aviv");
+    expect(locations).toContain("haifa");
+  });
+
+  it("returns empty array for text with no known locations", () => {
+    const text = "The stock market fell sharply on Tuesday amid global uncertainty.";
+    const locations = extractLocations(text);
+    expect(locations).toHaveLength(0);
+  });
+});
+
+// ─── Static geocoder ──────────────────────────────────────────────────────────
+
+describe("geocodeLocation — static lookup", () => {
+  beforeEach(() => resetGeocodingStats());
+
+  it("returns Tel Aviv coords from static lookup (lat≈32.08, lng≈34.78)", async () => {
+    const result = await geocodeLocation("tel aviv");
+    expect(result).not.toBeNull();
+    expect(result!.source).toBe("static");
+    expect(result!.lat).toBeCloseTo(32.08, 1);
+    expect(result!.lng).toBeCloseTo(34.78, 1);
+    expect(result!.countryCode).toBe("IL");
+  });
+
+  it("returns Gaza coords (lat≈31.5, lng≈34.467)", async () => {
+    const result = await geocodeLocation("gaza");
+    expect(result).not.toBeNull();
+    expect(result!.lat).toBeCloseTo(31.5, 1);
+    expect(result!.lng).toBeCloseTo(34.467, 1);
+    expect(result!.countryCode).toBe("PS");
+  });
+
+  it("resolves 'Hezbollah' alias → beirut coords", async () => {
+    const result = await geocodeLocation("hezbollah");
+    expect(result).not.toBeNull();
+    expect(result!.name).toBe("Beirut");
+    expect(result!.lat).toBeCloseTo(33.89, 1);
+  });
+
+  it("resolves 'Khan Yunis' alias correctly", async () => {
+    const result = await geocodeLocation("khan yunis");
+    expect(result).not.toBeNull();
+    expect(result!.countryCode).toBe("PS");
+  });
+
+  it("resolves 'Golan Heights'", async () => {
+    const result = await geocodeLocation("golan heights");
+    expect(result).not.toBeNull();
+    expect(result!.lat).toBeCloseTo(33.0, 0);
+  });
+});
+
+// ─── KV cache ─────────────────────────────────────────────────────────────────
+
+describe("geocodeLocation — KV cache", () => {
+  it("stores result in KV and returns from cache on second call", async () => {
+    const kv = new InMemoryKV();
+    // First call — static (will also cache)
+    const r1 = await geocodeLocation("haifa", { KV: kv });
+    expect(r1?.source).toBe("static");
+
+    // The static path writes to cache; manually clear the in-memory geo lookup for this test
+    // by calling with a location NOT in static — use a mocked fetch for Nominatim
+    const mockFetch = async (_url: string): Promise<Response> => {
+      const body = JSON.stringify([{
+        lat: "32.0853", lon: "34.7818", display_name: "Tel Aviv",
+        address: { country_code: "il" },
+      }]);
+      return new Response(body, { status: 200 });
+    };
+
+    // First external call — goes to Nominatim mock
+    const r2 = await geocodeLocation("test-location-xyz", { KV: kv, _fetch: mockFetch as typeof fetch });
+    expect(r2?.source).toBe("nominatim");
+
+    // Second call — should return from cache
+    const r3 = await geocodeLocation("test-location-xyz", { KV: kv, _fetch: mockFetch as typeof fetch });
+    expect(r3?.source).toBe("cache");
+  });
+});
+
+// ─── geocodeTextAsync ─────────────────────────────────────────────────────────
+
+describe("geocodeTextAsync", () => {
+  it("extracts 'Tel Aviv' from article text and returns lat≈32.08, lng≈34.78", async () => {
+    const text = `
+      BREAKING: IDF confirms missile intercepted over Tel Aviv.
+      The interception occurred at 02:34 local time as sirens sounded across the city.
+    `;
+    const result = await geocodeTextAsync(text);
+    expect(result).not.toBeNull();
+    expect(result!.lat).toBeCloseTo(32.08, 1);
+    expect(result!.lng).toBeCloseTo(34.78, 1);
+    expect(result!.countryCode).toBe("IL");
+  });
+
+  it("falls back to Nominatim for unknown location", async () => {
+    const mockFetch = async (_url: string): Promise<Response> => {
+      const body = JSON.stringify([{
+        lat: "35.6892", lon: "51.3890", display_name: "Tehran, Iran",
+        address: { country_code: "ir" },
+      }]);
+      return new Response(body, { status: 200 });
+    };
+
+    // Text with something that's not in our static list
+    const text = "Protests erupted in Tehran's central district near Azadi Square.";
+    // "Tehran" IS in static list so this tests static path
+    const result = await geocodeTextAsync(text, { _fetch: mockFetch as typeof fetch });
+    expect(result).not.toBeNull();
+    expect(result!.lat).toBeCloseTo(35.68, 1);
+  });
+});
+
+// ─── attachGeoToAlert ─────────────────────────────────────────────────────────
+
+describe("attachGeoToAlert", () => {
+  it("attaches lat/lng to alert without coordinates", async () => {
+    const alert = { headline: "Airstrike in Beirut kills 5", lat: null, lng: null, locationName: null, countryCode: null };
+    const text = "An airstrike in Beirut killed at least five people on Sunday.";
+    const result = await attachGeoToAlert(alert, text);
+    expect(result.lat).not.toBeNull();
+    expect(result.lng).not.toBeNull();
+    expect(result.countryCode).toBe("LB");
+  });
+
+  it("does not overwrite existing coordinates", async () => {
+    const alert = { lat: 10.0, lng: 20.0, locationName: "Custom", countryCode: "XX" };
+    const result = await attachGeoToAlert(alert, "Tel Aviv attacked");
+    expect(result.lat).toBe(10.0);
+    expect(result.lng).toBe(20.0);
+  });
+});
+
+// ─── Geocoding stats ──────────────────────────────────────────────────────────
+
+describe("getGeocodingStats", () => {
+  beforeEach(() => resetGeocodingStats());
+
+  it("tracks static hits correctly", async () => {
+    await geocodeLocation("tel aviv");
+    await geocodeLocation("gaza");
+    await geocodeLocation("beirut");
+    const stats = getGeocodingStats();
+    expect(stats.total).toBe(3);
+    expect(stats.hits.static).toBe(3);
+    expect(stats.failures).toBe(0);
+    expect(stats.hitRate).toBe(100);
+  });
+
+  it("tracks misses", async () => {
+    // No fetch → Nominatim will fail, Mapbox not configured
+    const noFetch = async (): Promise<Response> => { throw new Error("no network"); };
+    await geocodeLocation("definitely-not-a-place-xyzzy", { _fetch: noFetch as typeof fetch });
+    const stats = getGeocodingStats();
+    expect(stats.failures).toBe(1);
+  });
+});

--- a/backend/src/agents/geocoder.ts
+++ b/backend/src/agents/geocoder.ts
@@ -1,0 +1,372 @@
+/**
+ * Geocoding Pipeline
+ *
+ * Multi-layer geocoding:
+ *  1. Local static lookup (GEO_LOOKUP) — instant, covers all major ME conflict zones
+ *  2. Nominatim (free, no key) — external fallback
+ *  3. Mapbox (MAPBOX_ACCESS_TOKEN) — secondary fallback
+ *
+ * Results are cached in Redis/KV with key `geo:<normalised_location>` / TTL 7 days.
+ * Hit-rate and failure stats are logged on every geocode call.
+ */
+
+import { GEO_LOOKUP, type GeoLocation } from "./rssAggregator";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface GeocodeResult extends GeoLocation {
+  source: "static" | "nominatim" | "mapbox" | "cache";
+}
+
+export interface GeocoderEnv {
+  KV?: KVNamespace;
+  MAPBOX_ACCESS_TOKEN?: string;
+  _fetch?: typeof fetch;
+}
+
+// ─── KV type shims (for Node / test environments) ─────────────────────────────
+
+export interface KVNamespace {
+  get(key: string): Promise<string | null>;
+  put(key: string, value: string, opts?: { expirationTtl?: number }): Promise<void>;
+  delete(key: string): Promise<void>;
+  list(opts?: unknown): Promise<{ keys: Array<{ name: string }>; list_complete: boolean; cursor: string }>;
+  getWithMetadata<M = unknown>(key: string): Promise<{ value: string | null; metadata: M | null }>;
+}
+
+// ─── In-memory KV shim ────────────────────────────────────────────────────────
+
+export class InMemoryKV implements KVNamespace {
+  private store = new Map<string, { value: string; expiry?: number }>();
+
+  async get(key: string): Promise<string | null> {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+    if (entry.expiry && Date.now() > entry.expiry) { this.store.delete(key); return null; }
+    return entry.value;
+  }
+  async put(key: string, value: string, opts?: { expirationTtl?: number }): Promise<void> {
+    const expiry = opts?.expirationTtl ? Date.now() + opts.expirationTtl * 1000 : undefined;
+    this.store.set(key, { value, expiry });
+  }
+  async delete(key: string): Promise<void> { this.store.delete(key); }
+  async list(): Promise<{ keys: Array<{ name: string }>; list_complete: boolean; cursor: string }> {
+    return { keys: [], list_complete: true, cursor: "" };
+  }
+  async getWithMetadata<M = unknown>(key: string): Promise<{ value: string | null; metadata: M | null }> {
+    return { value: await this.get(key), metadata: null };
+  }
+}
+
+// ─── Redis/KV helpers ─────────────────────────────────────────────────────────
+
+const TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+
+async function cacheGet(kv: KVNamespace | undefined, key: string): Promise<GeocodeResult | null> {
+  if (!kv) return null;
+  try {
+    const raw = await kv.get(key);
+    if (!raw) return null;
+    return JSON.parse(raw) as GeocodeResult;
+  } catch { return null; }
+}
+
+async function cacheSet(kv: KVNamespace | undefined, key: string, value: GeocodeResult): Promise<void> {
+  if (!kv) return;
+  try { await kv.put(key, JSON.stringify(value), { expirationTtl: TTL_SECONDS }); } catch { /* non-fatal */ }
+}
+
+// ─── ME entity aliases ────────────────────────────────────────────────────────
+
+export const ME_ENTITY_ALIASES: Record<string, string> = {
+  // Gaza Strip
+  "gaza strip": "gaza",
+  "northern gaza": "gaza",
+  "southern gaza": "rafah",
+  "khan yunis": "khan younis",
+  "khan yunnis": "khan younis",
+  // West Bank
+  "the west bank": "west bank",
+  // Golan
+  "golan heights": "golan heights",
+  "the golan": "golan heights",
+  // South Lebanon
+  "southern lebanon": "south lebanon",
+  "south of lebanon": "south lebanon",
+  // Hezbollah / IRGC
+  "hezbollah": "beirut",
+  "hizballah": "beirut",
+  "hizb allah": "beirut",
+  "irgc": "tehran",
+  "islamic revolutionary guard corps": "tehran",
+  "quds force": "tehran",
+  "al-quds force": "tehran",
+  // Hamas / Islamic Jihad
+  "hamas": "gaza",
+  "islamic jihad": "gaza",
+  "pij": "gaza",
+  // Houthis
+  "houthis": "sanaa",
+  "houthi": "sanaa",
+  "ansar allah": "sanaa",
+  // Common aliases
+  "tel-aviv": "tel aviv",
+  "tel-aviv-jaffa": "tel aviv",
+  "jaffa": "tel aviv",
+  "al-quds": "jerusalem",
+  "east jerusalem": "jerusalem",
+  "west jerusalem": "jerusalem",
+};
+
+// Extended lookup — augments GEO_LOOKUP with any missing entries
+export const EXTENDED_GEO_LOOKUP: Record<string, GeoLocation> = {
+  ...GEO_LOOKUP,
+  "golan heights": { name: "Golan Heights", lat: 33.0, lng: 35.75, countryCode: "SY" },
+  "khan younis": (GEO_LOOKUP as Record<string, GeoLocation>)["khan younis"]
+    ?? { name: "Khan Younis", lat: 31.3452, lng: 34.3064, countryCode: "PS" },
+  "south lebanon": (GEO_LOOKUP as Record<string, GeoLocation>)["south lebanon"]
+    ?? (GEO_LOOKUP as Record<string, GeoLocation>)["southern lebanon"]
+    ?? { name: "South Lebanon", lat: 33.272, lng: 35.2033, countryCode: "LB" },
+};
+
+// ─── Location extractor ───────────────────────────────────────────────────────
+
+const SKIP_WORDS = new Set([
+  "the", "a", "an", "in", "on", "at", "of", "for", "and", "or", "but",
+  "mr", "ms", "dr", "gen", "col", "maj", "capt", "lt", "sgt",
+  "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+  "january", "february", "march", "april", "may", "june",
+  "july", "august", "september", "october", "november", "december",
+  "breaking", "exclusive", "updated", "report", "sources", "officials",
+  "united", "states", "nations", "security", "council",
+]);
+
+/**
+ * Extract candidate location strings from article text.
+ * Returns deduplicated list, static-lookup hits first.
+ */
+export function extractLocations(text: string): string[] {
+  const lower = text.toLowerCase();
+  const found: Set<string> = new Set();
+
+  // 1. Alias matching (longest first)
+  const aliasKeys = Object.keys(ME_ENTITY_ALIASES).sort((a, b) => b.length - a.length);
+  for (const alias of aliasKeys) {
+    if (lower.includes(alias)) {
+      found.add(ME_ENTITY_ALIASES[alias]!);
+    }
+  }
+
+  // 2. Static geo lookup keys (longest first)
+  const geoKeys = Object.keys(EXTENDED_GEO_LOOKUP).sort((a, b) => b.length - a.length);
+  for (const key of geoKeys) {
+    if (lower.includes(key)) found.add(key);
+  }
+
+  // 3. Title-Case NLP heuristic — only adds if there's a static match
+  const titleCaseRegex = /\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+){0,2})\b/g;
+  let m: RegExpExecArray | null;
+  while ((m = titleCaseRegex.exec(text)) !== null) {
+    const candidate = m[1]!.toLowerCase();
+    const words = candidate.split(/\s+/);
+    if (words.every((w) => !SKIP_WORDS.has(w)) && candidate.length > 2) {
+      if (EXTENDED_GEO_LOOKUP[candidate]) found.add(candidate);
+    }
+  }
+
+  return Array.from(found);
+}
+
+// ─── Stats ────────────────────────────────────────────────────────────────────
+
+let _stats = { total: 0, hits: { static: 0, cache: 0, nominatim: 0, mapbox: 0 }, failures: 0 };
+
+export function getGeocodingStats() {
+  const totalHits = Object.values(_stats.hits).reduce((a, b) => a + b, 0);
+  return { ..._stats, hitRate: _stats.total === 0 ? 0 : (totalHits / _stats.total) * 100 };
+}
+
+export function resetGeocodingStats() {
+  _stats = { total: 0, hits: { static: 0, cache: 0, nominatim: 0, mapbox: 0 }, failures: 0 };
+}
+
+function logStats(source: GeocodeResult["source"] | "miss", location: string) {
+  _stats.total++;
+  if (source === "miss") {
+    _stats.failures++;
+    console.warn(`[geocoder] MISS: "${location}"`);
+  } else {
+    _stats.hits[source]++;
+    if (source !== "static") console.log(`[geocoder] HIT via ${source}: "${location}"`);
+  }
+  if (_stats.total % 100 === 0) {
+    const s = getGeocodingStats();
+    console.log(`[geocoder] Stats — total:${s.total} hitRate:${s.hitRate.toFixed(1)}% failures:${s.failures}` +
+      ` (static:${s.hits.static} cache:${s.hits.cache} nominatim:${s.hits.nominatim} mapbox:${s.hits.mapbox})`);
+  }
+}
+
+// ─── Nominatim ────────────────────────────────────────────────────────────────
+
+async function geocodeNominatim(
+  location: string,
+  fetchFn: typeof fetch
+): Promise<Omit<GeocodeResult, "source"> | null> {
+  try {
+    const url = `https://nominatim.openstreetmap.org/search?q=${encodeURIComponent(location)}&format=json&limit=1&addressdetails=1`;
+    const res = await fetchFn(url, {
+      headers: { "User-Agent": "WarDashboard/1.0 (geocoding-pipeline)" },
+      signal: AbortSignal.timeout(8_000),
+    });
+    if (!res.ok) return null;
+    const data = (await res.json()) as Array<{
+      lat: string; lon: string; display_name: string;
+      address?: { country_code?: string };
+    }>;
+    if (!data.length || !data[0]) return null;
+    const r = data[0];
+    return {
+      name: location,
+      lat: parseFloat(r.lat),
+      lng: parseFloat(r.lon),
+      countryCode: (r.address?.country_code ?? "XX").toUpperCase(),
+    };
+  } catch { return null; }
+}
+
+// ─── Mapbox ───────────────────────────────────────────────────────────────────
+
+async function geocodeMapbox(
+  location: string,
+  token: string,
+  fetchFn: typeof fetch
+): Promise<Omit<GeocodeResult, "source"> | null> {
+  try {
+    const url = `https://api.mapbox.com/geocoding/v5/mapbox.places/${encodeURIComponent(location)}.json?access_token=${token}&limit=1`;
+    const res = await fetchFn(url, { signal: AbortSignal.timeout(8_000) });
+    if (!res.ok) return null;
+    const data = (await res.json()) as {
+      features?: Array<{
+        center: [number, number]; place_name: string;
+        context?: Array<{ id: string; short_code?: string }>;
+      }>;
+    };
+    const feature = data.features?.[0];
+    if (!feature) return null;
+    const [lng, lat] = feature.center;
+    const countryCtx = feature.context?.find((c) => c.id.startsWith("country."));
+    const countryCode = (countryCtx?.short_code ?? "XX").toUpperCase().slice(0, 2);
+    return { name: location, lat: lat!, lng: lng!, countryCode };
+  } catch { return null; }
+}
+
+// ─── Main geocoder ────────────────────────────────────────────────────────────
+
+/**
+ * Geocode a single location string.
+ * Ambiguous locations (aliases like "hezbollah", "gaza strip") are resolved via
+ * ME_ENTITY_ALIASES before lookup, so we always prefer known conflict-zone coords.
+ */
+export async function geocodeLocation(
+  location: string,
+  env: GeocoderEnv = {}
+): Promise<GeocodeResult | null> {
+  const normalised = location.toLowerCase().trim();
+  const cacheKey = `geo:${normalised}`;
+  const fetchFn = env._fetch ?? fetch;
+
+  // Resolve alias
+  const canonical = ME_ENTITY_ALIASES[normalised] ?? normalised;
+
+  // 1. Static lookup (highest priority)
+  const staticResult = EXTENDED_GEO_LOOKUP[canonical];
+  if (staticResult) {
+    const result: GeocodeResult = { ...staticResult, source: "static" };
+    logStats("static", location);
+    await cacheSet(env.KV, cacheKey, result);
+    return result;
+  }
+
+  // 2. KV/Redis cache
+  const cached = await cacheGet(env.KV, cacheKey);
+  if (cached) {
+    logStats("cache", location);
+    return { ...cached, source: "cache" };
+  }
+
+  // 3. Nominatim
+  const nominatimResult = await geocodeNominatim(canonical, fetchFn);
+  if (nominatimResult) {
+    const result: GeocodeResult = { ...nominatimResult, source: "nominatim" };
+    await cacheSet(env.KV, cacheKey, result);
+    logStats("nominatim", location);
+    return result;
+  }
+
+  // 4. Mapbox fallback
+  if (env.MAPBOX_ACCESS_TOKEN) {
+    const mapboxResult = await geocodeMapbox(canonical, env.MAPBOX_ACCESS_TOKEN, fetchFn);
+    if (mapboxResult) {
+      const result: GeocodeResult = { ...mapboxResult, source: "mapbox" };
+      await cacheSet(env.KV, cacheKey, result);
+      logStats("mapbox", location);
+      return result;
+    }
+  }
+
+  logStats("miss", location);
+  return null;
+}
+
+/**
+ * Extract locations from article text and geocode the best match.
+ * Static hits are returned immediately; external APIs are tried in order.
+ */
+export async function geocodeTextAsync(
+  text: string,
+  env: GeocoderEnv = {}
+): Promise<GeocodeResult | null> {
+  const locations = extractLocations(text);
+
+  // Try static-lookup candidates first
+  for (const loc of locations) {
+    const canonical = ME_ENTITY_ALIASES[loc] ?? loc;
+    if (EXTENDED_GEO_LOOKUP[canonical]) {
+      return geocodeLocation(loc, env);
+    }
+  }
+
+  // Try external APIs for remaining candidates
+  for (const loc of locations) {
+    const result = await geocodeLocation(loc, env);
+    if (result) return result;
+  }
+
+  return null;
+}
+
+/**
+ * Attach geo_lat / geo_lng to an alert-like object by geocoding its combined text.
+ * Does NOT overwrite existing coordinates.
+ */
+export async function attachGeoToAlert<
+  T extends {
+    lat?: number | null;
+    lng?: number | null;
+    locationName?: string | null;
+    countryCode?: string | null;
+  }
+>(
+  alert: T,
+  text: string,
+  env: GeocoderEnv = {}
+): Promise<T & { lat: number | null; lng: number | null }> {
+  if (alert.lat != null && alert.lng != null) {
+    return alert as T & { lat: number | null; lng: number | null };
+  }
+  const geo = await geocodeTextAsync(text, env);
+  if (geo) {
+    return { ...alert, lat: geo.lat, lng: geo.lng, locationName: geo.name, countryCode: geo.countryCode };
+  }
+  return { ...alert, lat: null, lng: null };
+}

--- a/backend/src/agents/rssAggregator.ts
+++ b/backend/src/agents/rssAggregator.ts
@@ -2,6 +2,7 @@ import { getDb, type Env } from "../../db/client";
 import { alerts, sources, strikes } from "../../db/schema";
 import { eq, inArray } from "drizzle-orm";
 import { scoreConfidence, getConfidenceLabel } from "./confidenceScorer";
+import { geocodeTextAsync } from "./geocoder";
 
 // ─── War keyword filter ───────────────────────────────────────────────────────
 
@@ -460,7 +461,7 @@ export async function processRssItems(
     }
 
     // New alert
-    const geo = geocodeText(text);
+    const geo = await geocodeTextAsync(text, { MAPBOX_ACCESS_TOKEN: (env as Record<string,string>)["MAPBOX_ACCESS_TOKEN"] ?? (env as Record<string,string>)["MAPBOX_TOKEN"] });
     const keywords = extractKeywords(text);
     const category = detectCategory(text);
     const nowMs = Date.now();

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*", "db/**/*"]
+}


### PR DESCRIPTION
## Overview

Implements a full geocoding pipeline for the War Dashboard backend. Location data is now extracted from article text and resolved to coordinates via a multi-layer system.

## Checklist

- [x] **Location extractor** — regex + NLP title-case heuristic to extract city/region names from article text (`extractLocations()`)
- [x] **ME entity list** — comprehensive alias map covering: Tel Aviv, Gaza, Beirut, Tehran, Baghdad, Jerusalem, Haifa, Damascus, Amman, Cairo, Rafah, Khan Yunis, West Bank, Gaza Strip, Golan Heights, South Lebanon, Hezbollah → Beirut, IRGC → Tehran, Hamas → Gaza, Houthis → Sanaa, and more
- [x] **Nominatim integration** — free, no API key — `GET https://nominatim.openstreetmap.org/search?q=<city>&format=json`
- [x] **Mapbox fallback** — reads `MAPBOX_ACCESS_TOKEN` env var; used when Nominatim returns no result
- [x] **Redis/KV cache** — key: `geo:<location>`, TTL: 7 days via Cloudflare KV (with `InMemoryKV` shim for Node environments)
- [x] **Attach geo to alerts** — `attachGeoToAlert()` wires lat/lng/locationName/countryCode onto alert records; `processRssItems()` now calls async geocoder
- [x] **Ambiguous location handling** — `ME_ENTITY_ALIASES` resolves ambiguous actors/regions to canonical conflict-zone coordinates (e.g. Gaza → 31.5, 34.467)
- [x] **Hit-rate logging** — `getGeocodingStats()` tracks total, per-source hits, failures, and hit rate %; logged periodically every 100 calls
- [x] **Tests (19 passing)** — covers: `extractLocations`, static geocode, KV cache round-trip, `geocodeTextAsync` (Tel Aviv: lat≈32.08, lng≈34.78), `attachGeoToAlert`, stats tracking

## Files Changed

- `backend/src/agents/geocoder.ts` — new geocoding module
- `backend/src/agents/__tests__/geocoder.test.ts` — 19 tests, all passing
- `backend/src/agents/rssAggregator.ts` — wired to use `geocodeTextAsync`
- `backend/package.json` + `backend/tsconfig.json` — added for local test running

## Testing

```bash
cd backend
/app/node_modules/.bin/vitest run src/agents/__tests__/geocoder.test.ts
# 19 passed
```